### PR TITLE
fix for latest version of sml/nj. CannotParse exception replaced with…

### DIFF
--- a/src/expect.sml
+++ b/src/expect.sml
@@ -190,7 +190,7 @@ struct
         let
             val (success, match) =
                 (true, StringCvt.scanString (RE.find (RE.compileString value)))
-            handle RegExpSyntax.CannotParse =>
+            handle RegExpSyntax.CannotCompile =>
                 (false, StringCvt.scanString (RE.find (RE.compileString "$")))
         in
             if success


### PR DESCRIPTION
… CannotCompile.